### PR TITLE
feat: implementation for custom protocols

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 		"maplibre-gl": "5.0.0-pre.6",
 		"mdsvex": "^0.12.3",
 		"mode-watcher": "^0.5.0",
+		"pmtiles": "^3.2.1",
 		"prettier": "^3.3.3",
 		"prettier-plugin-svelte": "^3.2.8",
 		"prettier-plugin-tailwindcss": "^0.6.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       mode-watcher:
         specifier: ^0.5.0
         version: 0.5.0(svelte@5.2.4)
+      pmtiles:
+        specifier: ^3.2.1
+        version: 3.2.1
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
@@ -667,6 +670,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/leaflet@1.9.14':
+    resolution: {integrity: sha512-sx2q6MDJaajwhKeVgPSvqXd8rhNJSTA3tMidQGduZn9S6WBYxDkCpSpV5xXEmSg7Cgdk/5vJGhVF1kMYLzauBg==}
+
   '@types/mapbox__point-geometry@0.1.4':
     resolution: {integrity: sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==}
 
@@ -1140,6 +1146,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -1601,6 +1610,9 @@ packages:
     resolution: {integrity: sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pmtiles@3.2.1:
+    resolution: {integrity: sha512-3R4fBwwoli5mw7a6t1IGwOtfmcSAODq6Okz0zkXhS1zi9sz1ssjjIfslwPvcWw5TNhdjNBUg9fgfPLeqZlH6ng==}
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -2723,6 +2735,10 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/leaflet@1.9.14':
+    dependencies:
+      '@types/geojson': 7946.0.14
+
   '@types/mapbox__point-geometry@0.1.4': {}
 
   '@types/mapbox__vector-tile@1.3.4':
@@ -3250,6 +3266,8 @@ snapshots:
 
   fdir@6.4.2: {}
 
+  fflate@0.8.2: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -3697,6 +3715,11 @@ snapshots:
       playwright-core: 1.49.0
     optionalDependencies:
       fsevents: 2.3.2
+
+  pmtiles@3.2.1:
+    dependencies:
+      '@types/leaflet': 1.9.14
+      fflate: 0.8.2
 
   postcss-import@15.1.0(postcss@8.4.49):
     dependencies:

--- a/src/content/examples/Index.svelte
+++ b/src/content/examples/Index.svelte
@@ -15,4 +15,5 @@
 	<li><a href="/examples/fullscreen">Fullscreen</a></li>
 	<li><a href="/examples/geolocate">Locate the User</a></li>
 	<li><a href="/examples/custom-control">Custom Control</a></li>
+	<li><a href="/examples/protocols">Protocols</a></li>
 </ul>

--- a/src/content/examples/protocols/Protocols.svelte
+++ b/src/content/examples/protocols/Protocols.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import { MapLibre, RasterTileSource, RasterLayer } from 'svelte-maplibre-gl';
+
+	const protocols: Record<string, maplibregl.AddProtocolAction> = {
+		myprotocol: async (params, _) => {
+			const zxy = params.url.replace('custom://', '');
+			const [z, x, y] = zxy.split('/').map((v) => parseInt(v, 10));
+
+			const png = await new Promise((resolve) => {
+				const canvas = document.createElement('canvas');
+				canvas.width = 256;
+				canvas.height = 256;
+				const context = canvas.getContext('2d')!;
+
+				// checkered pattern
+				context.fillStyle = (z + x - y) % 2 === 0 ? 'rgba(255, 255, 255, 0.5)' : 'rgba(0, 0, 0, 0.5)';
+				context.fillRect(0, 0, canvas.width, canvas.height);
+
+				// canvas to blob (png) to buffer
+				canvas.toBlob(async (blob) => {
+					const buf = await blob!.arrayBuffer();
+					resolve(buf);
+				});
+			});
+
+			return { data: png };
+		}
+	};
+</script>
+
+<MapLibre
+	class="h-[50vh] min-h-[200px]"
+	style="https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json"
+	zoom={12}
+	center={{ lng: 140.09085, lat: 40.3 }}
+	{protocols}
+>
+	<RasterTileSource tiles={['myprotocol://{z}/{x}/{y}']} tileSize={256}>
+		<RasterLayer />
+	</RasterTileSource>
+</MapLibre>

--- a/src/content/examples/protocols/Protocols.svelte
+++ b/src/content/examples/protocols/Protocols.svelte
@@ -8,7 +8,7 @@
 	const protocols: Record<string, maplibregl.AddProtocolAction> = {
 		pmtiles: pmtilesProtocol.tile,
 		myprotocol: async (params, _) => {
-			const zxy = params.url.replace('custom://', '');
+			const zxy = params.url.replace('myprotocol://', '');
 			const [z, x, y] = zxy.split('/').map((v) => parseInt(v, 10));
 
 			const png = await new Promise((resolve) => {

--- a/src/content/examples/protocols/Protocols.svelte
+++ b/src/content/examples/protocols/Protocols.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
-	import { MapLibre, RasterTileSource, RasterLayer } from 'svelte-maplibre-gl';
+	import { MapLibre, RasterTileSource, VectorTileSource, RasterLayer, LineLayer, FillLayer } from 'svelte-maplibre-gl';
+
+	// @ts-ignore
+	import { Protocol } from 'pmtiles';
+	const pmtilesProtocol = new Protocol();
 
 	const protocols: Record<string, maplibregl.AddProtocolAction> = {
+		pmtiles: pmtilesProtocol.tile,
 		myprotocol: async (params, _) => {
 			const zxy = params.url.replace('custom://', '');
 			const [z, x, y] = zxy.split('/').map((v) => parseInt(v, 10));
@@ -30,11 +35,29 @@
 
 <MapLibre
 	class="h-[50vh] min-h-[200px]"
-	style="https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json"
-	zoom={12}
-	center={{ lng: 140.09085, lat: 40.3 }}
+	style={{
+		version: 8,
+		sources: {},
+		layers: []
+	}}
+	zoom={6}
+	center={{ lng: 140.09085, lat: 37.3 }}
 	{protocols}
 >
+	<VectorTileSource url="pmtiles://https://tile.openstreetmap.jp/static/planet.pmtiles">
+		<LineLayer
+			sourceLayer="transportation"
+			paint={{
+				'line-color': 'red'
+			}}
+		/>
+		<FillLayer
+			sourceLayer="water"
+			paint={{
+				'fill-color': 'blue'
+			}}
+		/>
+	</VectorTileSource>
 	<RasterTileSource tiles={['myprotocol://{z}/{x}/{y}']} tileSize={256}>
 		<RasterLayer />
 	</RasterTileSource>

--- a/src/content/examples/protocols/content.svelte.md
+++ b/src/content/examples/protocols/content.svelte.md
@@ -1,0 +1,14 @@
+---
+title: Protocols
+description: Interface to add custom protocols.
+---
+
+<script lang="ts">
+  import Protocols from "./Protocols.svelte";
+  import demoRaw from "./Protocols.svelte?raw";
+  import CodeBlock from "../../CodeBlock.svelte";
+</script>
+
+<Protocols />
+
+<CodeBlock content={demoRaw} />

--- a/src/lib/maplibre/map/MapLibre.svelte
+++ b/src/lib/maplibre/map/MapLibre.svelte
@@ -28,6 +28,9 @@
 		repaint?: boolean;
 		vertices?: boolean;
 
+		// for addProtocol()
+		protocols?: Record<string, maplibregl.AddProtocolAction>;
+
 		// Snippets
 		children?: Snippet;
 	}
@@ -105,6 +108,9 @@
 		repaint,
 		vertices,
 
+		// addProtocol()
+		protocols,
+
 		// Map Options (reactive)
 		bearing = $bindable(undefined),
 		bearingSnap,
@@ -146,6 +152,11 @@
 	let loaded = $state(false);
 
 	const mapCtx = prepareMapContext();
+
+	// set protocols to maplibregl
+	Object.entries(protocols ?? {}).forEach(([protocol, fn]) => {
+		maplibregl.addProtocol(protocol, fn);
+	});
 
 	$effect(() => {
 		if (map || !container) {


### PR DESCRIPTION
<!-- Close or Related Issues -->

related close #8 

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

- This PR is the implementation for custom protocols using `maplibregl.addProtocol()`.
- you can find example page in http://localhost:5173/examples/protocols

### Notes
<!-- If manual testing is required, please describe the procedure. -->

- Please tell me better interfaces if you have!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a new "Protocols" link in the examples section for easier navigation.
  - Introduced a new mapping interface that supports custom tile protocols and displays vector and raster tiles.
  - Added documentation for custom protocols to enhance user understanding.

- **Enhancements**
  - Integrated a new optional property for custom protocols in the mapping component, allowing for more flexibility in map configuration.
  - Updated project dependencies to include `pmtiles` for improved functionality.

These updates improve usability and expand functionality for users working with map interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->