### PR TITLE
Defer dynamic style operations until the current style is fully loaded

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,7 +20,10 @@ export default ts.config(
 	},
 	{
 		files: ['**/*.svelte'],
-
+		rules: {
+			// surpress "Expected an assignment or function call and instead saw an expression"
+			'@typescript-eslint/no-unused-expressions': 'off'
+		},
 		languageOptions: {
 			parserOptions: {
 				parser: ts.parser

--- a/src/content/CodeBlock.svelte
+++ b/src/content/CodeBlock.svelte
@@ -23,6 +23,7 @@
 </script>
 
 <div class="my-6 subpixel-antialiased">
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 	{@html highlighted}
 </div>
 

--- a/src/content/examples/terrain/content.svelte.md
+++ b/src/content/examples/terrain/content.svelte.md
@@ -1,6 +1,6 @@
 ---
 title: 3D Terrain
-description: 3D terrain and sky.
+description: 3D terrain and the sky.
 ---
 
 <script lang="ts">

--- a/src/lib/maplibre/controls/GeolocateControl.svelte
+++ b/src/lib/maplibre/controls/GeolocateControl.svelte
@@ -7,7 +7,7 @@
 	import { resetEventListener } from '../utils.js';
 	import type { Listener, Event } from '../types.js';
 
-	type GeolocateEvent = Event<maplibregl.GeolocateControl> & Object;
+	type GeolocateEvent = Event<maplibregl.GeolocateControl> & object;
 
 	interface Props extends maplibregl.GeolocateControlOptions {
 		position?: maplibregl.ControlPosition;
@@ -46,6 +46,7 @@
 	$effect(() => resetEventListener(control, 'trackuserlocationstart', ontrackuserlocationstart));
 	$effect(() => resetEventListener(control, 'trackuserlocationend', ontrackuserlocationend));
 	$effect(() => resetEventListener(control, 'userlocationlostfocus', onuserlocationlostfocus));
+	$effect(() => resetEventListener(control, 'userlocationfocus', onuserlocationfocus));
 	$effect(() => resetEventListener(control, 'geolocate', ongeolocate));
 	$effect(() => resetEventListener(control, 'error', onerror));
 	$effect(() => resetEventListener(control, 'outofmaxbounds', onoutofmaxbounds));

--- a/src/lib/maplibre/controls/Hash.svelte
+++ b/src/lib/maplibre/controls/Hash.svelte
@@ -7,7 +7,7 @@
 	import maplibregl from 'maplibre-gl';
 	import { getMapContext } from '../contexts.svelte.js';
 
-	let {}: {} = $props();
+	// let {}: {} = $props();
 
 	const mapCtx = getMapContext();
 	if (!mapCtx.map) throw new Error('Map instance is not initialized.');

--- a/src/lib/maplibre/layers/RawLayer.svelte
+++ b/src/lib/maplibre/layers/RawLayer.svelte
@@ -81,7 +81,10 @@
 		}
 	}
 
-	mapCtx.addLayer(addLayerObj, beforeId);
+	let firstRun = true;
+	mapCtx.waitForStyleLoaded(() => {
+		mapCtx.addLayer(addLayerObj, beforeId);
+	});
 
 	$effect(() => resetLayerEventListener(mapCtx.map, 'click', id, onclick));
 	$effect(() => resetLayerEventListener(mapCtx.map, 'dblclick', id, ondblclick));
@@ -97,64 +100,70 @@
 	$effect(() => resetLayerEventListener(mapCtx.map, 'touchend', id, ontouchend));
 	$effect(() => resetLayerEventListener(mapCtx.map, 'touchcancel', id, ontouchcancel));
 
-	let firstRun = true;
-
 	let prevPaint: Record<string, unknown> = $state.snapshot(paint) ?? {};
 	$effect(() => {
 		paint;
-		const map = mapCtx.map;
-		if (!firstRun && map) {
-			const keysRemoved = new Set(Object.keys(prevPaint));
-			const _paint = $state.snapshot(paint) ?? {};
-			for (const [key, value] of Object.entries(_paint)) {
-				keysRemoved.delete(key);
-				if (prevPaint[key] !== value) {
-					map.setPaintProperty(id, key, value);
+		if (!firstRun) {
+			mapCtx.waitForStyleLoaded((map) => {
+				const keysRemoved = new Set(Object.keys(prevPaint));
+				const _paint = $state.snapshot(paint) ?? {};
+				for (const [key, value] of Object.entries(_paint)) {
+					keysRemoved.delete(key);
+					if (prevPaint[key] !== value) {
+						map.setPaintProperty(id, key, value);
+					}
 				}
-			}
-			for (const key of keysRemoved) {
-				map.setPaintProperty(id, key, undefined);
-			}
-			prevPaint = _paint;
+				for (const key of keysRemoved) {
+					map.setPaintProperty(id, key, undefined);
+				}
+				prevPaint = _paint;
+			});
 		}
 	});
 
 	let prevLayout: Record<string, unknown> = $state.snapshot(layout) ?? {};
 	$effect(() => {
 		layout;
-		const map = mapCtx.map;
-		if (!firstRun && map) {
-			const keysRemoved = new Set(Object.keys(prevLayout));
-			const _layout = $state.snapshot(layout) ?? {};
-			for (const [key, value] of Object.entries(_layout)) {
-				keysRemoved.delete(key);
-				if (prevLayout[key] !== value) {
-					map.setLayoutProperty(id, key, value);
+		if (!firstRun) {
+			mapCtx.waitForStyleLoaded((map) => {
+				const keysRemoved = new Set(Object.keys(prevLayout));
+				const _layout = $state.snapshot(layout) ?? {};
+				for (const [key, value] of Object.entries(_layout)) {
+					keysRemoved.delete(key);
+					if (prevLayout[key] !== value) {
+						map.setLayoutProperty(id, key, value);
+					}
 				}
-			}
-			for (const key of keysRemoved) {
-				map.setLayoutProperty(id, key, undefined);
-			}
-			prevLayout = _layout;
+				for (const key of keysRemoved) {
+					map.setLayoutProperty(id, key, undefined);
+				}
+				prevLayout = _layout;
+			});
 		}
 	});
 
 	$effect(() => {
 		if ((minzoom !== undefined || maxzoom !== undefined) && !firstRun) {
-			mapCtx.map?.setLayerZoomRange(id, minzoom ?? 0, maxzoom ?? 22);
+			mapCtx.waitForStyleLoaded((map) => {
+				map.setLayerZoomRange(id, minzoom ?? 0, maxzoom ?? 22);
+			});
 		}
 	});
 
 	$effect(() => {
 		filter;
 		if (!firstRun) {
-			mapCtx.map?.setFilter(id, filter);
+			mapCtx.waitForStyleLoaded((map) => {
+				map.setFilter(id, filter);
+			});
 		}
 	});
 
 	$effect(() => {
 		if (beforeId && !firstRun) {
-			mapCtx.map?.moveLayer(id, beforeId);
+			mapCtx.waitForStyleLoaded((map) => {
+				map.moveLayer(id, beforeId);
+			});
 		}
 	});
 

--- a/src/lib/maplibre/map/Light.svelte
+++ b/src/lib/maplibre/map/Light.svelte
@@ -12,11 +12,15 @@
 
 	$effect(() => {
 		mapCtx.userLight = $state.snapshot(spec) as maplibregl.LightSpecification;
-		mapCtx.map?.setLight(mapCtx.userLight);
+		mapCtx.waitForStyleLoaded((map) => {
+			map.setLight(mapCtx.userLight as maplibregl.LightSpecification);
+		});
 	});
 
 	onDestroy(() => {
 		mapCtx.userLight = undefined;
-		mapCtx.map?.setLight(mapCtx.baseLight ?? {});
+		mapCtx.waitForStyleLoaded((map) => {
+			map.setLight(mapCtx.baseLight ?? {});
+		});
 	});
 </script>

--- a/src/lib/maplibre/map/MapLibre.svelte
+++ b/src/lib/maplibre/map/MapLibre.svelte
@@ -143,7 +143,6 @@
 	}: Props = $props();
 
 	let container: HTMLElement | undefined = $state();
-	let loaded = $state(false);
 
 	const mapCtx = prepareMapContext();
 
@@ -197,38 +196,35 @@
 		}
 
 		map = new maplibregl.Map(filteredOptions);
+		mapCtx.map = map ?? null;
 
-		map.on('load', () => {
-			mapCtx.map = map ?? null;
-			loaded = true;
-		});
-
-		map.on('move', (ev) => {
-			if (map) {
-				const tr = map.transform;
-				if (center) {
-					const _center = maplibregl.LngLat.convert(center);
-					if (_center.lat !== tr.center.lat || _center.lng !== tr.center.lng) {
-						center = formatLngLat(center, tr.center);
-					}
-				} else {
-					center = tr.center;
+		map.on('move', () => {
+			if (!map) {
+				return;
+			}
+			const tr = map.transform;
+			if (center) {
+				const _center = maplibregl.LngLat.convert(center);
+				if (_center.lat !== tr.center.lat || _center.lng !== tr.center.lng) {
+					center = formatLngLat(center, tr.center);
 				}
-				if (tr.zoom !== zoom) {
-					zoom = tr.zoom;
-				}
-				if (tr.bearing !== bearing) {
-					bearing = tr.bearing;
-				}
-				if (tr.pitch !== pitch) {
-					pitch = tr.pitch;
-				}
-				if (tr.roll !== roll) {
-					roll = tr.roll;
-				}
-				if (tr.elevation !== elevation) {
-					elevation = tr.elevation;
-				}
+			} else {
+				center = tr.center;
+			}
+			if (tr.zoom !== zoom) {
+				zoom = tr.zoom;
+			}
+			if (tr.bearing !== bearing) {
+				bearing = tr.bearing;
+			}
+			if (tr.pitch !== pitch) {
+				pitch = tr.pitch;
+			}
+			if (tr.roll !== roll) {
+				roll = tr.roll;
+			}
+			if (tr.elevation !== elevation) {
+				elevation = tr.elevation;
 			}
 		});
 	});
@@ -542,7 +538,7 @@
 </script>
 
 <div class={className} style={inlineStyle} bind:this={container}>
-	{#if map && loaded}
+	{#if map}
 		{@render children?.()}
 	{/if}
 </div>

--- a/src/lib/maplibre/map/Projection.svelte
+++ b/src/lib/maplibre/map/Projection.svelte
@@ -5,7 +5,7 @@
 	import maplibregl from 'maplibre-gl';
 	import { getMapContext } from '../contexts.svelte.js';
 
-	interface Props extends maplibregl.ProjectionSpecification {}
+	type Props = maplibregl.ProjectionSpecification;
 	let { ...spec }: Props = $props();
 
 	const mapCtx = getMapContext();
@@ -13,11 +13,15 @@
 
 	$effect(() => {
 		mapCtx.userProjection = $state.snapshot(spec) as maplibregl.ProjectionSpecification;
-		mapCtx.map?.setProjection(mapCtx.userProjection);
+		mapCtx.waitForStyleLoaded((map) => {
+			map.setProjection(mapCtx.userProjection as maplibregl.ProjectionSpecification);
+		});
 	});
 
 	onDestroy(() => {
 		mapCtx.userProjection = undefined;
-		mapCtx.map?.setProjection(mapCtx.baseProjection ?? { type: 'mercator' });
+		mapCtx.waitForStyleLoaded((map) => {
+			map.setProjection(mapCtx.baseProjection ?? { type: 'mercator' });
+		});
 	});
 </script>

--- a/src/lib/maplibre/map/Sky.svelte
+++ b/src/lib/maplibre/map/Sky.svelte
@@ -12,11 +12,15 @@
 
 	$effect(() => {
 		mapCtx.userSky = $state.snapshot(spec) as maplibregl.SkySpecification;
-		mapCtx.map?.setSky(mapCtx.userSky);
+		mapCtx.waitForStyleLoaded((map) => {
+			map.setSky(mapCtx.userSky as maplibregl.SkySpecification);
+		});
 	});
 
 	onDestroy(() => {
 		mapCtx.userSky = undefined;
-		mapCtx.map?.setSky(mapCtx.baseSky as maplibregl.SkySpecification);
+		mapCtx.waitForStyleLoaded((map) => {
+			map.setSky(mapCtx.baseSky as maplibregl.SkySpecification);
+		});
 	});
 </script>

--- a/src/lib/maplibre/map/Sprite.svelte
+++ b/src/lib/maplibre/map/Sprite.svelte
@@ -15,10 +15,14 @@
 		if (!mapCtx.map) {
 			return;
 		}
-		mapCtx.map.addSprite(id, url);
+		mapCtx.waitForStyleLoaded((map) => {
+			map.addSprite(id, url);
+		});
 
 		return () => {
-			mapCtx.map?.removeSprite(id);
+			mapCtx.waitForStyleLoaded((map) => {
+				map.removeSprite(id);
+			});
 		};
 	});
 </script>

--- a/src/lib/maplibre/map/Terrain.svelte
+++ b/src/lib/maplibre/map/Terrain.svelte
@@ -21,11 +21,15 @@
 			...spec,
 			source: sourceId
 		});
-		mapCtx.map?.setTerrain(mapCtx.userTerrain);
+		mapCtx.waitForStyleLoaded((map) => {
+			map.setTerrain((mapCtx.userTerrain as maplibregl.TerrainSpecification) || null);
+		});
 	});
 
 	onDestroy(() => {
 		mapCtx.userTerrain = undefined;
-		mapCtx.map?.setTerrain(mapCtx.baseTerrain ?? null);
+		mapCtx.waitForStyleLoaded((map) => {
+			map.setTerrain(mapCtx.baseTerrain ?? null);
+		});
 	});
 </script>

--- a/src/lib/maplibre/sources/FeatureState.svelte
+++ b/src/lib/maplibre/sources/FeatureState.svelte
@@ -7,7 +7,7 @@
 
 	interface Props extends Omit<maplibregl.FeatureIdentifier, 'source'> {
 		source?: string;
-		state: Record<string, any>;
+		state: Record<string, unknown>;
 		children?: Snippet;
 	}
 

--- a/src/lib/maplibre/sources/RawSource.svelte
+++ b/src/lib/maplibre/sources/RawSource.svelte
@@ -27,14 +27,16 @@
 	const mapCtx = getMapContext();
 	if (!mapCtx.map) throw new Error('Map instance is not initialized.');
 
+	let firstRun = true;
+
 	const id = _id ?? generateSourceID();
-	mapCtx.addSource(id, $state.snapshot(spec) as Specs);
 	const sourceCtx = prepareSourceContext();
 	sourceCtx.id = id;
-	source = mapCtx.map.getSource(id);
-	if (!source) throw new Error(`Failed to add source {id}`);
-
-	let firstRun = true;
+	mapCtx.waitForStyleLoaded((map) => {
+		mapCtx.addSource(id, $state.snapshot(spec) as Specs);
+		source = map.getSource(id);
+		firstRun = true;
+	});
 
 	$effect(() => {
 		if (source && spec.type !== 'canvas' && spec.type !== 'video' && spec.type !== 'image') {
@@ -115,6 +117,7 @@
 	});
 
 	$effect(() => {
+		source;
 		firstRun = false;
 	});
 
@@ -124,6 +127,4 @@
 	});
 </script>
 
-{#if source}
-	{@render children?.()}
-{/if}
+{@render children?.()}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,3 +1,3 @@
-export async function load({ setHeaders }) {
-	setHeaders({ 'Cache-Control': 'max-age=7200, stale-while-revalidate=3600' });
-}
+// export async function load({ setHeaders }) {
+// 	setHeaders({ 'Cache-Control': 'max-age=7200, stale-while-revalidate=3600' });
+// }

--- a/src/routes/Header.svelte
+++ b/src/routes/Header.svelte
@@ -11,14 +11,14 @@
 	import { goto } from '$app/navigation';
 
 	if (browser) {
-		// @ts-expect-error: DocSearch types are not properly exposed
+		// @ts-expect-error: DocSearch types are not properly exposed (?)
 		docsearch({
 			container: '#docsearch',
 			appId: '78TOQ3W600',
 			indexName: 'svelte-maplibre-gl',
 			apiKey: '096ebe16a7ae7b573fc996e9a08edbc0',
 			navigator: {
-				// @ts-expect-error
+				// @ts-expect-error: DocSearch types are not properly exposed (?)
 				navigate({ itemUrl }) {
 					const url = new URL(itemUrl);
 					goto(url.pathname + url.search + url.hash);


### PR DESCRIPTION
Close #2

This pull request includes several changes to improve the handling of map styles and ensure that operations are only performed when the map style is fully loaded.

The most important changes involve the introduction of a `waitForStyleLoaded` method and modifications to various components to utilize this method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of map properties and events, ensuring operations are performed only after the map's style is fully loaded.
	- Improved control flow for setting light, projection, terrain, and sky settings on the map.
	- Added support for managing sprites with synchronized addition and removal based on map readiness.
	- Introduced a new event listener for user location focus in the geolocate control.
	- Updated syntax highlighting for Svelte code in the CodeBlock component.
	- Minor updates to metadata descriptions for content files.

- **Bug Fixes**
	- Added error handling to ensure operations on the map only proceed if it is initialized.

- **Documentation**
	- Updated comments to clarify changes in the handling of map context and source management.

- **Refactor**
	- Streamlined logic for updating map properties and event listeners, enhancing overall robustness.
	- Simplified the retrieval and management of sources and layers within the map context.
	- Enhanced type safety in the feature state management.
	- Adjusted ESLint configuration to suppress specific warnings for Svelte files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->