### PR TITLE
feat: implement `<Protocol/>` for custom protocols

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 		"maplibre-gl": "5.0.0-pre.7",
 		"mdsvex": "^0.12.3",
 		"mode-watcher": "^0.5.0",
+		"pmtiles": "^3.2.1",
 		"prettier": "^3.3.3",
 		"prettier-plugin-svelte": "^3.3.1",
 		"prettier-plugin-tailwindcss": "^0.6.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       mode-watcher:
         specifier: ^0.5.0
         version: 0.5.0(svelte@5.2.7)
+      pmtiles:
+        specifier: ^3.2.1
+        version: 3.2.1
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
@@ -667,6 +670,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/leaflet@1.9.14':
+    resolution: {integrity: sha512-sx2q6MDJaajwhKeVgPSvqXd8rhNJSTA3tMidQGduZn9S6WBYxDkCpSpV5xXEmSg7Cgdk/5vJGhVF1kMYLzauBg==}
+
   '@types/mapbox__point-geometry@0.1.4':
     resolution: {integrity: sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==}
 
@@ -1140,6 +1146,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -1601,6 +1610,9 @@ packages:
     resolution: {integrity: sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pmtiles@3.2.1:
+    resolution: {integrity: sha512-3R4fBwwoli5mw7a6t1IGwOtfmcSAODq6Okz0zkXhS1zi9sz1ssjjIfslwPvcWw5TNhdjNBUg9fgfPLeqZlH6ng==}
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -2723,6 +2735,10 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/leaflet@1.9.14':
+    dependencies:
+      '@types/geojson': 7946.0.14
+
   '@types/mapbox__point-geometry@0.1.4': {}
 
   '@types/mapbox__vector-tile@1.3.4':
@@ -3250,6 +3266,8 @@ snapshots:
 
   fdir@6.4.2: {}
 
+  fflate@0.8.2: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -3697,6 +3715,11 @@ snapshots:
       playwright-core: 1.49.0
     optionalDependencies:
       fsevents: 2.3.2
+
+  pmtiles@3.2.1:
+    dependencies:
+      '@types/leaflet': 1.9.14
+      fflate: 0.8.2
 
   postcss-import@15.1.0(postcss@8.4.49):
     dependencies:

--- a/src/content/examples/Index.svelte
+++ b/src/content/examples/Index.svelte
@@ -15,4 +15,5 @@
 	<li><a href="/examples/fullscreen">Fullscreen</a></li>
 	<li><a href="/examples/geolocate">Locate the User</a></li>
 	<li><a href="/examples/custom-control">Custom Control</a></li>
+	<li><a href="/examples/custom-protocol">Custom Protocol</a></li>
 </ul>

--- a/src/content/examples/custom-protocol/CustomProtocol.svelte
+++ b/src/content/examples/custom-protocol/CustomProtocol.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	import {
+		MapLibre,
+		RasterTileSource,
+		VectorTileSource,
+		RasterLayer,
+		LineLayer,
+		FillLayer,
+		Protocol
+	} from 'svelte-maplibre-gl';
+
+	// @ts-ignore
+	import { Protocol as PmtilesProtocol } from 'pmtiles';
+	const pmtilesProtocol = new PmtilesProtocol();
+</script>
+
+<!-- add custom protocols -->
+<Protocol name="pmtiles" loadFn={pmtilesProtocol.tile} />
+<Protocol
+	name="myprotocol"
+	loadFn={async (params, _) => {
+		const zxy = params.url.replace('myprotocol://', '');
+		const [z, x, y] = zxy.split('/').map((v) => parseInt(v, 10));
+
+		const png = await new Promise((resolve) => {
+			const canvas = document.createElement('canvas');
+			canvas.width = 256;
+			canvas.height = 256;
+			const context = canvas.getContext('2d')!;
+
+			// checkered pattern
+			context.fillStyle = (z + x - y) % 2 === 0 ? 'rgba(255, 255, 255, 0.5)' : 'rgba(0, 0, 0, 0.5)';
+			context.fillRect(0, 0, canvas.width, canvas.height);
+
+			// canvas to blob (png) to buffer
+			canvas.toBlob(async (blob) => {
+				const buf = await blob!.arrayBuffer();
+				resolve(buf);
+			});
+		});
+
+		return { data: png };
+	}}
+/>
+
+<MapLibre
+	class="h-[50vh] min-h-[200px]"
+	style={{
+		version: 8,
+		sources: {},
+		layers: []
+	}}
+	zoom={6}
+	center={{ lng: 140.09085, lat: 37.3 }}
+>
+	<VectorTileSource url="pmtiles://https://tile.openstreetmap.jp/static/planet.pmtiles">
+		<LineLayer
+			sourceLayer="transportation"
+			paint={{
+				'line-color': 'red'
+			}}
+		/>
+		<FillLayer
+			sourceLayer="water"
+			paint={{
+				'fill-color': 'blue'
+			}}
+		/>
+	</VectorTileSource>
+	<RasterTileSource tiles={['myprotocol://{z}/{x}/{y}']} tileSize={256}>
+		<RasterLayer />
+	</RasterTileSource>
+</MapLibre>

--- a/src/content/examples/custom-protocol/content.svelte.md
+++ b/src/content/examples/custom-protocol/content.svelte.md
@@ -1,0 +1,14 @@
+---
+title: Custom Protocols
+description: How to add custom protocols.
+---
+
+<script lang="ts">
+  import CustomProtocol from "./CustomProtocol.svelte";
+  import demoRaw from "./CustomProtocol.svelte?raw";
+  import CodeBlock from "../../CodeBlock.svelte";
+</script>
+
+<CustomProtocol />
+
+<CodeBlock content={demoRaw} />

--- a/src/lib/maplibre/Protocol.svelte
+++ b/src/lib/maplibre/Protocol.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+
+	import maplibregl from 'maplibre-gl';
+
+	const { name, loadFn }: { name: string; loadFn: maplibregl.AddProtocolAction } = $props();
+
+	$effect(() => {
+		maplibregl.addProtocol(name, loadFn); // no error even when already added
+	});
+
+	onDestroy(() => {
+		maplibregl.removeProtocol(name);
+	});
+</script>

--- a/src/lib/maplibre/Protocol.svelte
+++ b/src/lib/maplibre/Protocol.svelte
@@ -6,10 +6,9 @@
 	const { name, loadFn }: { name: string; loadFn: maplibregl.AddProtocolAction } = $props();
 
 	$effect(() => {
-		maplibregl.addProtocol(name, loadFn); // no error even when already added
-	});
-
-	onDestroy(() => {
-		maplibregl.removeProtocol(name);
+		maplibregl.addProtocol(name, loadFn);
+		return () => {
+			maplibregl.removeProtocol(name);
+		};
 	});
 </script>

--- a/src/lib/maplibre/index.ts
+++ b/src/lib/maplibre/index.ts
@@ -1,5 +1,8 @@
 // Reexport your entry components here
 
+// protocol
+export { default as Protocol } from './Protocol.svelte';
+
 // map
 export { default as MapLibre } from './map/MapLibre.svelte';
 export { default as Sky } from './map/Sky.svelte';


### PR DESCRIPTION
<!-- Close or Related Issues -->

related close #8 

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

- This PR is the implementation for custom protocols using `maplibregl.addProtocol()`.
- you can find example page in http://localhost:5173/examples/custom-protocol

### Notes
<!-- If manual testing is required, please describe the procedure. -->

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a new "Custom Protocol" link in the examples section for easier navigation.
  - Introduced a custom mapping interface that supports PMTiles and user-defined protocols, enhancing tile handling capabilities.
  - Added documentation for custom protocols to facilitate user understanding and implementation.

- **Enhancements**
  - Updated project dependencies to include `pmtiles` for improved functionality.

These updates improve usability and expand functionality for users working with map interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->