### PR TITLE
Enable two-way bindings for Popup’s open/close state

### DIFF
--- a/src/content/examples/complex/Complex.svelte
+++ b/src/content/examples/complex/Complex.svelte
@@ -49,6 +49,7 @@
 	let bearing = $state(0);
 	let controlPosition: maplibregl.ControlPosition | undefined = $state('bottom-right');
 	let markerLnglat = $state({ lng: 139.767052, lat: 35.681167 });
+	let popupOpen = $state(false);
 </script>
 
 <div class="flex items-center gap-x-2 p-1 text-sm">
@@ -127,6 +128,9 @@
 	<label>
 		z:
 		<input type="number" min="0" max="24" step="0.5" bind:value={zoom} class="w-12 rounded border p-1 leading-none" />
+	</label>
+	<label>
+		<input type="checkbox" bind:checked={popupOpen} /> Popup Open
 	</label>
 	<label>
 		<input type="checkbox" bind:checked={hash} /> Hash
@@ -277,7 +281,7 @@
 		{#snippet content()}
 			<span class="text-3xl">🐸</span>
 		{/snippet}
-		<Popup class="text-black">
+		<Popup class="text-black" bind:open={popupOpen}>
 			<span class="text-lg">
 				{`${markerLnglat.lat.toFixed(3)}, ${markerLnglat.lng.toFixed(3)}`}
 			</span>


### PR DESCRIPTION
Close #51 

## Summary by Copilot

This pull request introduces a new feature to control the visibility of popups in the `Complex.svelte` example and the `Popup.svelte` component. The most important changes include adding a state variable for the popup's open state, binding this state to a checkbox in the UI, and updating the `Popup.svelte` component to handle the open state.

### Enhancements to `Popup.svelte` component:

* Introduced an `open` property to the `Popup` component to manage its visibility. [[1]](diffhunk://#diff-b724ef22030c6f5bb00f1107d88ad81047c6b122c6c4e30020bd2d79a981147aL7-R11) [[2]](diffhunk://#diff-b724ef22030c6f5bb00f1107d88ad81047c6b122c6c4e30020bd2d79a981147aR26)
* Updated the logic to add or remove the popup from the map based on the `open` property. [[1]](diffhunk://#diff-b724ef22030c6f5bb00f1107d88ad81047c6b122c6c4e30020bd2d79a981147aL72-R75) [[2]](diffhunk://#diff-b724ef22030c6f5bb00f1107d88ad81047c6b122c6c4e30020bd2d79a981147aR86-R127)

### Enhancements to `Complex.svelte` example:

* Added a new state variable `popupOpen` to control the popup's visibility.
* Added a checkbox to the UI to bind the `popupOpen` state, allowing users to toggle the popup.
* Bound the `open` property of the `Popup` component to the `popupOpen` state.
