### PR TITLE
doc: doc-overview-quickstart

### DIFF
--- a/src/content/CodeBlock.svelte
+++ b/src/content/CodeBlock.svelte
@@ -17,20 +17,20 @@
 	});
 </script>
 
-<div class="my-6 subpixel-antialiased">
+<div class="line-numbers my-6 subpixel-antialiased">
 	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 	{@html shiki.codeToHtml(_content, { lang: 'svelte', theme: 'github-dark-default' })}
 </div>
 
 <style>
-	:global(.shiki code) {
+	:global(.line-numbers .shiki code) {
 		font-size: 13px;
 		tab-size: 2;
 		counter-reset: step;
 		counter-increment: step 0;
 	}
 
-	:global(.shiki code .line::before) {
+	:global(.line-numbers .shiki code .line::before) {
 		content: counter(step);
 		counter-increment: step;
 		width: 1em;

--- a/src/content/docs/quickstart/Maplibre.svelte
+++ b/src/content/docs/quickstart/Maplibre.svelte
@@ -2,5 +2,6 @@
 	import { MapLibre } from 'svelte-maplibre-gl';
 </script>
 
-<!-- Height must be set! You can use TailwindCSS syntax for styling. -->
+<!-- Height must be set, otherwise the map size will be zero! -->
+<!-- Our examples use Tailwind CSS classes for styling. -->
 <MapLibre class="h-[540px]" style="https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json" />

--- a/src/content/docs/quickstart/Maplibre.svelte
+++ b/src/content/docs/quickstart/Maplibre.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+	import { MapLibre } from 'svelte-maplibre-gl';
+</script>
+
+<!-- Height must set! You can use TailwindCSS syntax for styling. -->
+<MapLibre class="h-[540px]" style="https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json" />

--- a/src/content/docs/quickstart/Maplibre.svelte
+++ b/src/content/docs/quickstart/Maplibre.svelte
@@ -2,5 +2,5 @@
 	import { MapLibre } from 'svelte-maplibre-gl';
 </script>
 
-<!-- Height must set! You can use TailwindCSS syntax for styling. -->
+<!-- Height must be set! You can use TailwindCSS syntax for styling. -->
 <MapLibre class="h-[540px]" style="https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json" />

--- a/src/content/docs/quickstart/content.svelte.md
+++ b/src/content/docs/quickstart/content.svelte.md
@@ -20,7 +20,7 @@ cd myapp
 npm install
 ```
 
-### Install svelte-maplibre-gl
+## Install svelte-maplibre-gl
 
 ```
 npm install -D svelte-maplibre-gl

--- a/src/content/docs/quickstart/content.svelte.md
+++ b/src/content/docs/quickstart/content.svelte.md
@@ -14,7 +14,7 @@ description: Get started with svelte-maplibre-gl in a few minutes.
 
 ```
 npx sv create mymap
-# TailwindCSS option must be enabled, svelte-maplibre-gl uses depends on it.
+# TailwindCSS option must be enabled, svelte-maplibre-gl depends on it.
 
 cd myapp
 npm install

--- a/src/content/docs/quickstart/content.svelte.md
+++ b/src/content/docs/quickstart/content.svelte.md
@@ -26,7 +26,7 @@ npm install
 npm install -D svelte-maplibre-gl
 ```
 
-Then you can make a map of MapLibre GL JS only with few lines of code.
+Then you can make a map of MapLibre GL JS only with one line of code.
 
 <CodeBlock content={maplibreRaw} {shiki} />
 <Maplibre />

--- a/src/content/docs/quickstart/content.svelte.md
+++ b/src/content/docs/quickstart/content.svelte.md
@@ -1,0 +1,32 @@
+---
+title: Quickstart
+description: Get started with svelte-maplibre-gl in a few minutes.
+---
+
+<script lang="ts">
+  import Maplibre from "./Maplibre.svelte";
+  import maplibreRaw from "./Maplibre.svelte?raw";
+  import CodeBlock from "../../CodeBlock.svelte";
+  let { shiki } = $props();
+</script>
+
+## Launch SvelteKit project
+
+```
+npx sv create mymap
+# TailwindCSS option must be enabled, svelte-maplibre-gl uses depends on it.
+
+cd myapp
+npm install
+```
+
+### Install svelte-maplibre-gl
+
+```
+npm install -D svelte-maplibre-gl
+```
+
+Then you can make a map of MapLibre GL JS only with few lines of code.
+
+<CodeBlock content={maplibreRaw} {shiki} />
+<Maplibre />

--- a/src/content/docs/quickstart/content.svelte.md
+++ b/src/content/docs/quickstart/content.svelte.md
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-description: Get started with svelte-maplibre-gl in a few minutes.
+description: Get started with svelte-maplibre-gl in just a few minutes.
 ---
 
 <script lang="ts">
@@ -10,23 +10,28 @@ description: Get started with svelte-maplibre-gl in a few minutes.
   let { shiki } = $props();
 </script>
 
-## Launch SvelteKit project
+## 1. Launch a SvelteKit Project
 
-```
+Create a new SvelteKit project using the official [Svelte CLI](https://svelte.dev/docs/kit/creating-a-project).
+
+```bash
 npx sv create mymap
-# TailwindCSS option must be enabled, svelte-maplibre-gl depends on it.
+# Make sure to enable the Tailwind CSS add-on,
+# as our example use it for styling.
 
 cd myapp
 npm install
 ```
 
-## Install svelte-maplibre-gl
+## 2. Install `svelte-maplibre-gl`
 
-```
+```bash
 npm install -D svelte-maplibre-gl
 ```
 
-Then you can make a map of MapLibre GL JS only with one line of code.
+## 3. Add the Simplest Map
+
+Now you can add the simplest MapLibre GL JS map to your `+page.svelte` file with just one line of code.
 
 <CodeBlock content={maplibreRaw} {shiki} />
 <Maplibre />

--- a/src/content/docs/toc.ts
+++ b/src/content/docs/toc.ts
@@ -1,0 +1,11 @@
+import type { Toc } from '$lib/components/types';
+
+export const toc: Toc = [
+	{
+		title: 'Overview',
+		items: {
+			'/docs/quickstart': 'Quickstart',
+			// '/docs/Concept': 'Concept',
+		}
+	}
+];

--- a/src/routes/Header.svelte
+++ b/src/routes/Header.svelte
@@ -48,6 +48,12 @@
 		</h1>
 		<nav class="ml-12 hidden gap-x-4 font-medium min-[550px]:flex">
 			<a
+				href="/docs/"
+				data-active={page.url.pathname.startsWith('/docs/')}
+				class="text-sm text-foreground/70 transition-colors hover:text-foreground data-[active=true]:font-semibold"
+				>Docs
+			</a>
+			<a
 				href="/examples/"
 				data-active={page.url.pathname.startsWith('/examples/')}
 				class="text-sm text-foreground/70 transition-colors hover:text-foreground data-[active=true]:font-semibold"

--- a/src/routes/docs/+layout.ts
+++ b/src/routes/docs/+layout.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/src/routes/docs/+page.svelte
+++ b/src/routes/docs/+page.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import Index from '$lib/components/Index.svelte';
+
+	import { toc } from '$content/docs/toc.js';
+</script>
+
+<div id="toc" class="m-auto p-8 xl:container">
+	<Index name="Docs" {toc} />
+</div>
+
+<style>
+	#toc {
+		view-transition-name: toc;
+	}
+</style>

--- a/src/routes/docs/+page.ts
+++ b/src/routes/docs/+page.ts
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit';
+
+export function load() {
+	redirect(302, '/docs/quickstart');
+}

--- a/src/routes/docs/[slug]/+layout.svelte
+++ b/src/routes/docs/[slug]/+layout.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import Index from '$lib/components/Index.svelte';
+	import { toc } from '$content/docs/toc';
+
+	let { children } = $props();
+</script>
+
+<div class="mx-auto grid gap-4 px-4 xl:container md:grid-cols-[210px_minmax(0,1fr)] md:px-8">
+	<aside class="sticky bottom-0 top-16 hidden h-[calc(100vh-4rem)] overflow-scroll py-8 md:block">
+		<Index name="Docs" {toc} />
+	</aside>
+	<main class="grid-cols-[1fr_210px]">
+		{@render children()}
+	</main>
+</div>

--- a/src/routes/docs/[slug]/+page.svelte
+++ b/src/routes/docs/[slug]/+page.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import * as Breadcrumb from '$lib/components/ui/breadcrumb/index.js';
+	const { data } = $props();
+</script>
+
+<div class="grid gap-x-8 lg:grid-cols-[1fr_160px]">
+	<div class="min-h-[calc(100vh-4rem)] w-full min-w-0 py-8">
+		<Breadcrumb.Root class="mb-4">
+			<Breadcrumb.List>
+				<Breadcrumb.Item>
+					<Breadcrumb.Link href="/docs/">Docs</Breadcrumb.Link>
+				</Breadcrumb.Item>
+				<Breadcrumb.Separator />
+				<Breadcrumb.Item>
+					<Breadcrumb.Page>{data.meta.title}</Breadcrumb.Page>
+				</Breadcrumb.Item>
+			</Breadcrumb.List>
+		</Breadcrumb.Root>
+
+		<h1 class="mb-2 text-3xl font-bold">{data.meta.title}</h1>
+		<p class="mb-6 text-muted-foreground">
+			{data.meta.description}
+		</p>
+
+		<div class="prose max-w-none dark:prose-invert">
+			<data.Content shiki={data.shiki} />
+		</div>
+	</div>
+	<aside class="sticky top-24 hidden h-[calc(100vh-6rem)] lg:block">
+		<div class="font-medium">On This Page</div>
+	</aside>
+</div>
+
+<svelte:head>
+	<title>{data.meta.title} - Svelte MapLibre GL</title>
+	<meta name="description" content={data.meta.description} />
+</svelte:head>

--- a/src/routes/docs/[slug]/+page.ts
+++ b/src/routes/docs/[slug]/+page.ts
@@ -1,0 +1,34 @@
+import { error } from '@sveltejs/kit';
+import type { Component } from 'svelte';
+import { browser } from '$app/environment';
+
+import { createHighlighter, createJavaScriptRegexEngine, createOnigurumaEngine } from 'shiki';
+import svelte from 'shiki/langs/svelte.mjs';
+import dark from 'shiki/themes/github-dark-default.mjs';
+
+const shiki = createHighlighter({
+	themes: [dark],
+	langs: [svelte],
+	engine: browser ? createOnigurumaEngine(import('shiki/wasm')) : createJavaScriptRegexEngine()
+});
+
+export const load = async ({ params }) => {
+	const { slug } = params;
+
+	try {
+		const post = (await import(`$content/docs/${slug}/content.svelte.md`)) as {
+			default: Component;
+			metadata: {
+				title: string;
+				description: string;
+			};
+		};
+		return {
+			Content: post.default,
+			meta: { ...post.metadata, slug },
+			shiki: await shiki
+		};
+	} catch {
+		error(404, `Docs '${slug}' not found`);
+	}
+};

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -5,7 +5,7 @@ import { createHighlighter } from 'shiki';
 const theme = 'github-dark-default';
 const highlighter = await createHighlighter({
 	themes: [theme],
-	langs: ['javascript', 'typescript', 'svelte']
+	langs: ['javascript', 'typescript', 'svelte', 'bash']
 });
 
 /** @type {import('mdsvex').MdsvexOptions} */


### PR DESCRIPTION
<!-- Close or Related Issues -->

Close #60 

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

- added `/docs` and add `Quickstart` as a first step.
- refers: https://visgl.github.io/react-map-gl/docs

### Notes
<!-- If manual testing is required, please describe the procedure. -->

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `<MapLibre>` component for enhanced map rendering.
	- Added a quickstart guide for using the `svelte-maplibre-gl` library.
	- Enhanced documentation navigation with a new link to the `/docs/` section.
	- Implemented a table of contents for documentation pages.
	- Created responsive layouts for documentation pages with sticky sidebars.
	- Added breadcrumb navigation for improved user experience in documentation.
	- Expanded syntax highlighting support to include additional languages.

- **Bug Fixes**
	- Ensured dynamic loading of documentation content based on slug parameters.
	- Implemented automatic redirection to the quickstart documentation page.

- **Chores**
	- Added metadata and structure for documentation files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->