### PR TITLE
docs: link rel=canonical

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,10 +5,19 @@
 	import Header from './Header.svelte';
 	import GlobalToc from './GlobalToc.svelte';
 	import ViewTransition from './ViewTransition.svelte';
+	import { page } from '$app/state';
 
 	let { children } = $props();
 
 	let globalTocOpen = $state(false);
+
+	let canonicalUrl = $derived.by(() => {
+		const url = page.url;
+		url.protocol = 'https:';
+		url.hostname = 'svelte-maplibre-gl.mierune.dev';
+		url.port = '';
+		return url.toString();
+	});
 </script>
 
 <ModeWatcher />
@@ -33,4 +42,5 @@
 
 <svelte:head>
 	<title>Svelte MapLibre GL</title>
+	<link rel="canonical" href={canonicalUrl} />
 </svelte:head>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -22,7 +22,8 @@
 		<p>
 			<img src={heroImage} alt="hero" />
 		</p>
-		<p class="font-bold">Features:</p>
+
+		<h3 class="font-bold">Features:</h3>
 		<ul>
 			<li>The most declarative and reactive MapLibre GL JS experience, powered by Svelte 5</li>
 			<li>
@@ -30,8 +31,16 @@
 			</li>
 			<li>Freedom preserved — Traditional imperative MapLibre GL JS usage remains fully supported</li>
 		</ul>
-		<p class="font-bold">Installation:</p>
+
+		<h3 class="font-bold">Installation:</h3>
 		<pre><code>npm install --save-dev svelte-maplibre-gl</code></pre>
+
+		<h3 class="font-bold">Contents:</h3>
+		<ul>
+			<li><a href="/docs/quickstart">Quickstart</a></li>
+			<li><a href="/examples">Examples</a></li>
+			<li><a href="/docs/components">API Reference</a></li>
+		</ul>
 	</main>
 </div>
 


### PR DESCRIPTION
Ensuring the preview environment (*.svelte-maplibre-gl.pages.dev) is not indexed.