### PR TITLE
fix: Terradraw ext not working (using `terra-draw-maplibre-gl-adapter` 1.0.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
 		"pmtiles": "^4.0.0",
 		"svelte": ">=5.0.0",
 		"terra-draw": "^1.0.0",
-		"terra-draw-maplibre-gl-adapter": "^1.0.1"
+		"terra-draw-maplibre-gl-adapter": "^1.0.3"
 	},
 	"devDependencies": {
 		"@deck.gl/layers": "^9.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^1.0.0
         version: 1.2.0
       terra-draw-maplibre-gl-adapter:
-        specifier: ^1.0.1
-        version: 1.0.1(maplibre-gl@5.2.0)(terra-draw@1.2.0)
+        specifier: ^1.0.3
+        version: 1.0.3(maplibre-gl@5.2.0)(terra-draw@1.2.0)
     devDependencies:
       '@deck.gl/layers':
         specifier: ^9.1.4
@@ -2851,8 +2851,8 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
 
-  terra-draw-maplibre-gl-adapter@1.0.1:
-    resolution: {integrity: sha512-B5zM6OhOEwcYegNLP2HybOc+V0ZaQNYuSkOiAcGABV6ZVd5zZCX51GIXcAgOL07okcs1D+7a+4zCgqtD/fLgTg==}
+  terra-draw-maplibre-gl-adapter@1.0.3:
+    resolution: {integrity: sha512-Qd9xtV5Fa7JSJsKA5vJwvJZ40waiI9neDDvKUqCTcEjsrZCLVZQuiabcDhOO/Xv/vONk7io5MSPnlF6Mp1dwEA==}
     peerDependencies:
       maplibre-gl: '>=4'
       terra-draw: ^1.0.0
@@ -5679,7 +5679,7 @@ snapshots:
 
   tapable@2.2.1: {}
 
-  terra-draw-maplibre-gl-adapter@1.0.1(maplibre-gl@5.2.0)(terra-draw@1.2.0):
+  terra-draw-maplibre-gl-adapter@1.0.3(maplibre-gl@5.2.0)(terra-draw@1.2.0):
     dependencies:
       maplibre-gl: 5.2.0
       terra-draw: 1.2.0

--- a/src/lib/maplibre/ext/terradraw/TerraDraw.svelte
+++ b/src/lib/maplibre/ext/terradraw/TerraDraw.svelte
@@ -44,26 +44,13 @@
 		ondeselect?: DeselectListener;
 	} = $props();
 
-	mapCtx.map?.once('style.load', () => {
+	mapCtx.waitForStyleLoaded((map) => {
 		draw = new Draw({
-			adapter: new TerraDrawMapLibreGLAdapter({ map: mapCtx.map }),
+			adapter: new TerraDrawMapLibreGLAdapter({ map }),
 			modes,
 			idStrategy,
 			tracked
 		});
-	});
-
-	$effect.pre(() => {
-		if (!draw) {
-			const isLoaded = mapCtx.map?.isStyleLoaded();
-			if (!isLoaded) return;
-			draw = new Draw({
-				adapter: new TerraDrawMapLibreGLAdapter({ map: mapCtx.map }),
-				modes,
-				idStrategy,
-				tracked
-			});
-		}
 	});
 
 	$effect(() => {

--- a/src/lib/maplibre/ext/terradraw/TerraDraw.svelte
+++ b/src/lib/maplibre/ext/terradraw/TerraDraw.svelte
@@ -53,6 +53,19 @@
 		});
 	});
 
+	$effect.pre(() => {
+		if (!draw) {
+			const isLoaded = mapCtx.map?.isStyleLoaded();
+			if (!isLoaded) return;
+			draw = new Draw({
+				adapter: new TerraDrawMapLibreGLAdapter({ map: mapCtx.map }),
+				modes,
+				idStrategy,
+				tracked
+			});
+		}
+	});
+
 	$effect(() => {
 		draw?.start();
 		return () => draw?.stop();

--- a/src/lib/maplibre/ext/terradraw/TerraDraw.svelte
+++ b/src/lib/maplibre/ext/terradraw/TerraDraw.svelte
@@ -44,45 +44,47 @@
 		ondeselect?: DeselectListener;
 	} = $props();
 
-	draw = new Draw({
-		adapter: new TerraDrawMapLibreGLAdapter({ map: mapCtx.map }),
-		modes,
-		idStrategy,
-		tracked
+	mapCtx.map?.once('style.load', () => {
+		draw = new Draw({
+			adapter: new TerraDrawMapLibreGLAdapter({ map: mapCtx.map }),
+			modes,
+			idStrategy,
+			tracked
+		});
 	});
 
 	$effect(() => {
-		draw.start();
-		return () => draw.stop();
+		draw?.start();
+		return () => draw?.stop();
 	});
 	$effect(() => {
-		draw.setMode(mode);
+		draw?.setMode(mode);
 	});
 
 	// Event listeners
 	$effect(() => {
 		if (!onready) return;
-		draw.on('ready', onready);
-		return () => draw.off('ready', onready);
+		draw?.on('ready', onready);
+		return () => draw?.off('ready', onready);
 	});
 	$effect(() => {
 		if (!onfinish) return;
-		draw.on('finish', onfinish);
-		return () => draw.off('finish', onfinish);
+		draw?.on('finish', onfinish);
+		return () => draw?.off('finish', onfinish);
 	});
 	$effect(() => {
 		if (!onchange) return;
-		draw.on('change', onchange);
-		return () => draw.off('change', onchange);
+		draw?.on('change', onchange);
+		return () => draw?.off('change', onchange);
 	});
 	$effect(() => {
 		if (!onselect) return;
-		draw.on('select', onselect);
-		return () => draw.off('select', onselect);
+		draw?.on('select', onselect);
+		return () => draw?.off('select', onselect);
 	});
 	$effect(() => {
 		if (!ondeselect) return;
-		draw.on('deselect', ondeselect);
-		return () => draw.off('deselect', ondeselect);
+		draw?.on('deselect', ondeselect);
+		return () => draw?.off('deselect', ondeselect);
 	});
 </script>


### PR DESCRIPTION
<!-- Close or Related Issues -->

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

- update dependency `terra-draw-maplibre-gl-adapter`
- TerraDraw's initialize after `style.load`
  - relate https://github.com/JamesLMilner/terra-draw/issues/533

### Notes
<!-- If manual testing is required, please describe the procedure. -->

Confirmed to work with `terra-draw-maplibre-gl-adapter` 1.0.1