### PR TITLE
feat: Add dataDiff prop for incremental GeoJSON updates via updateData()

### DIFF
--- a/.changeset/geojson-update-data.md
+++ b/.changeset/geojson-update-data.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre-gl': minor
+---
+
+Add `dataDiff` prop to `GeoJSONSource` for incremental updates via MapLibre's `updateData()` API. Property-only changes skip the full geojson-vt re-tile, significantly improving performance for large datasets.

--- a/svelte-maplibre-gl/src/lib/sources/GeoJSONSource.svelte
+++ b/svelte-maplibre-gl/src/lib/sources/GeoJSONSource.svelte
@@ -9,11 +9,12 @@
 	interface Props extends Omit<maplibregl.GeoJSONSourceSpecification, 'type'> {
 		id?: string;
 		source?: maplibregl.GeoJSONSource;
+		dataDiff?: maplibregl.GeoJSONSourceDiff;
 		children?: Snippet;
 	}
-	let { source = $bindable(undefined), id, children, ...spec }: Props = $props();
+	let { source = $bindable(undefined), id, children, dataDiff, ...spec }: Props = $props();
 </script>
 
-<RawSource {id} bind:source type="geojson" {...spec}>
+<RawSource {id} bind:source type="geojson" {dataDiff} {...spec}>
 	{@render children?.()}
 </RawSource>

--- a/svelte-maplibre-gl/src/lib/sources/RawSource.svelte
+++ b/svelte-maplibre-gl/src/lib/sources/RawSource.svelte
@@ -89,19 +89,28 @@
 			}
 		}
 	});
+	let prevData: maplibregl.GeoJSONSourceSpecification['data'] | undefined;
 	$effect(() => {
 		if (source && spec.type === 'geojson') {
-			spec.data;
+			const dataChanged = spec.data !== prevData;
+			prevData = spec.data;
+			// Read dataDiff to subscribe even when data also changed
+			const diff = dataDiff;
+
 			if (!firstRun) {
-				(source as maplibregl.GeoJSONSource).setData(spec.data);
-			}
-		}
-	});
-	$effect(() => {
-		if (source && spec.type === 'geojson') {
-			dataDiff;
-			if (!firstRun && dataDiff) {
-				(source as maplibregl.GeoJSONSource).updateData(dataDiff);
+				const geojsonSource = source as maplibregl.GeoJSONSource;
+				if (dataChanged) {
+					// Full replace takes priority — skip any pending diff
+					geojsonSource.setData(spec.data);
+				} else if (diff) {
+					if (typeof geojsonSource.updateData !== 'function') {
+						throw new Error(
+							'GeoJSONSource.updateData requires MapLibre GL JS v4+. ' +
+								'Upgrade "maplibre-gl" or avoid the "dataDiff" prop.'
+						);
+					}
+					geojsonSource.updateData(diff);
+				}
 			}
 		}
 	});

--- a/svelte-maplibre-gl/src/lib/sources/RawSource.svelte
+++ b/svelte-maplibre-gl/src/lib/sources/RawSource.svelte
@@ -19,9 +19,10 @@
 	type Props = {
 		id?: string;
 		source?: Source;
+		dataDiff?: maplibregl.GeoJSONSourceDiff;
 		children?: Snippet;
 	} & Specs;
-	let { source = $bindable(undefined), id: _id, children, ...spec }: Props = $props();
+	let { source = $bindable(undefined), id: _id, children, dataDiff, ...spec }: Props = $props();
 	spec = spec as Specs;
 
 	const mapCtx = getMapContext();
@@ -92,8 +93,15 @@
 		if (source && spec.type === 'geojson') {
 			spec.data;
 			if (!firstRun) {
-				// TODO: support diffrential update ? (updateData)
 				(source as maplibregl.GeoJSONSource).setData(spec.data);
+			}
+		}
+	});
+	$effect(() => {
+		if (source && spec.type === 'geojson') {
+			dataDiff;
+			if (!firstRun && dataDiff) {
+				(source as maplibregl.GeoJSONSource).updateData(dataDiff);
 			}
 		}
 	});

--- a/svelte-maplibre-gl/src/lib/sources/RawSource.svelte
+++ b/svelte-maplibre-gl/src/lib/sources/RawSource.svelte
@@ -89,28 +89,26 @@
 			}
 		}
 	});
-	let prevData: maplibregl.GeoJSONSourceSpecification['data'] | undefined;
 	$effect(() => {
 		if (source && spec.type === 'geojson') {
-			const dataChanged = spec.data !== prevData;
-			prevData = spec.data;
-			// Read dataDiff to subscribe even when data also changed
-			const diff = dataDiff;
-
+			spec.data;
 			if (!firstRun) {
+				(source as maplibregl.GeoJSONSource).setData(spec.data);
+			}
+		}
+	});
+	$effect(() => {
+		if (source && spec.type === 'geojson') {
+			dataDiff;
+			if (!firstRun && dataDiff) {
 				const geojsonSource = source as maplibregl.GeoJSONSource;
-				if (dataChanged) {
-					// Full replace takes priority — skip any pending diff
-					geojsonSource.setData(spec.data);
-				} else if (diff) {
-					if (typeof geojsonSource.updateData !== 'function') {
-						throw new Error(
-							'GeoJSONSource.updateData requires MapLibre GL JS v4+. ' +
-								'Upgrade "maplibre-gl" or avoid the "dataDiff" prop.'
-						);
-					}
-					geojsonSource.updateData(diff);
+				if (typeof geojsonSource.updateData !== 'function') {
+					throw new Error(
+						'GeoJSONSource.updateData requires MapLibre GL JS v4+. ' +
+							'Upgrade "maplibre-gl" or avoid the "dataDiff" prop.'
+					);
 				}
+				geojsonSource.updateData(dataDiff);
 			}
 		}
 	});


### PR DESCRIPTION
### Summary

Adds a `dataDiff` prop to `GeoJSONSource` (and `RawSource`) that calls MapLibre's [`GeoJSONSource.updateData(diff)`](https://maplibre.org/maplibre-gl-js/docs/API/classes/GeoJSONSource/#updatedata) instead of `setData()`. This resolves the TODO comment at RawSource.svelte line 95:

```
// TODO: support diffrential update ? (updateData)
```

### Motivation

For applications rendering large GeoJSON datasets (thousands of features), every `data` prop change currently triggers a full `setData()` — which serializes the entire FeatureCollection to a web worker, re-runs geojson-vt tiling from scratch, and re-uploads all visible tiles to the GPU.

MapLibre GL JS v4+ provides `updateData(diff)` which accepts incremental diffs. When only feature properties change (not geometry), this skips the full re-tile entirely — only updating affected features in-place and reloading intersecting tiles.

### Usage

```svelte
<script>
  import { GeoJSONSource } from 'svelte-maplibre-gl';
  import type { GeoJSONSourceDiff } from 'maplibre-gl';

  let data = $state(initialGeoJSON);
  let dataDiff = $state<GeoJSONSourceDiff | undefined>(undefined);

  function updateColors() {
    // Incremental: only update properties, skip re-tiling
    dataDiff = {
      update: features.map(f => ({
        id: f.id,
        addOrUpdateProperties: [
          { key: 'color', value: computeColor(f) }
        ]
      }))
    };
  }
</script>

<GeoJSONSource {data} {dataDiff}>
  <CircleLayer paint={{ 'circle-color': ['get', 'color'] }} />
</GeoJSONSource>
```

- `data` → calls `setData()` (full replace) — use for structural changes
- `dataDiff` → calls `updateData()` (incremental) — use for property-only changes
- Both props can coexist: initial load via `data`, subsequent updates via `dataDiff`

### Changes

- **RawSource.svelte**: Added `dataDiff` to Props type, new `$effect` that calls `source.updateData(dataDiff)` (same pattern as existing `setData` effect)
- **GeoJSONSource.svelte**: Added `dataDiff` to Props interface, passes through to RawSource

### Checklist

- [x] `pnpm check:all` — 0 errors, 0 warnings (11/11 packages)
- [x] `pnpm build:packages` — all packages build
- [x] `pnpm test:unit -- --run` — all tests pass
- [x] Non-breaking: new optional prop, existing behavior unchanged
- [x] Changeset included (minor version bump)