### PR TITLE
fix: republish extensions with caret peer dependency ranges

### DIFF
--- a/.changeset/fix-extension-peer-ranges.md
+++ b/.changeset/fix-extension-peer-ranges.md
@@ -1,0 +1,7 @@
+---
+'@svelte-maplibre-gl/contour': patch
+'@svelte-maplibre-gl/deckgl': patch
+'@svelte-maplibre-gl/pmtiles': patch
+---
+
+Republish extensions so their `svelte-maplibre-gl` peer dependency is published as a caret range instead of an exact version.


### PR DESCRIPTION
Resolves #172

Republish extensions so their `svelte-maplibre-gl` peer dependency is published as a caret range instead of an exact version.