### PR TITLE
fix: resolve source effects before camera effects

### DIFF
--- a/.changeset/empty-dragons-feel.md
+++ b/.changeset/empty-dragons-feel.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre-gl': patch
+---
+
+Effects in Map run before effect in Source - using effect.pre ensures they come before

--- a/.changeset/empty-dragons-feel.md
+++ b/.changeset/empty-dragons-feel.md
@@ -2,4 +2,4 @@
 'svelte-maplibre-gl': patch
 ---
 
-Effects in Map run before effect in Source - using effect.pre ensures they come before
+Use `$effect.pre` for source tile updates so they run before the map’s option/camera effects when both change in the same tick.

--- a/svelte-maplibre-gl/src/lib/sources/RawSource.svelte
+++ b/svelte-maplibre-gl/src/lib/sources/RawSource.svelte
@@ -52,7 +52,8 @@
 			}
 		}
 	});
-	$effect(() => {
+	// ensure it runs before options change (child effects run after parent conponent's effects)
+	$effect.pre(() => {
 		if (
 			source &&
 			'setTiles' in source &&
@@ -79,7 +80,11 @@
 				return;
 			}
 
-			source.setTiles(spec.tiles ?? []);
+			const tiles = spec.tiles ?? [];
+			// force sync write until fix in maplibre-gl
+			source.tiles = tiles;
+
+			source.setTiles(tiles);
 		}
 	});
 	$effect(() => {

--- a/svelte-maplibre-gl/src/lib/sources/RawSource.svelte
+++ b/svelte-maplibre-gl/src/lib/sources/RawSource.svelte
@@ -85,7 +85,8 @@
 			source.setTiles(spec.tiles ?? []);
 		}
 	});
-	$effect(() => {
+	// ensure it runs before options change (child effects run after parent component's effects)
+	$effect.pre(() => {
 		if (source && (spec.type === 'vector' || spec.type === 'raster' || spec.type === 'raster-dem')) {
 			spec.url;
 			if (!firstRun && 'setUrl' in source && spec.url !== source.url) {

--- a/svelte-maplibre-gl/src/lib/sources/RawSource.svelte
+++ b/svelte-maplibre-gl/src/lib/sources/RawSource.svelte
@@ -80,9 +80,12 @@
 				return;
 			}
 
-			source.tiles = spec.tiles ?? []; // force sync write until fix in maplibre-gl
+			const tiles = spec.tiles ?? [];
 
-			source.setTiles(spec.tiles ?? []);
+			// TODO: remove if this gets merged: https://github.com/maplibre/maplibre-gl-js/pull/7910
+			source.tiles = tiles; // force sync write until fix in maplibre-gl
+
+			source.setTiles(tiles);
 		}
 	});
 	// ensure it runs before options change (child effects run after parent component's effects)

--- a/svelte-maplibre-gl/src/lib/sources/RawSource.svelte
+++ b/svelte-maplibre-gl/src/lib/sources/RawSource.svelte
@@ -80,11 +80,9 @@
 				return;
 			}
 
-			const tiles = spec.tiles ?? [];
-			// force sync write until fix in maplibre-gl
-			source.tiles = tiles;
+			source.tiles = spec.tiles ?? []; // force sync write until fix in maplibre-gl
 
-			source.setTiles(tiles);
+			source.setTiles(spec.tiles ?? []);
 		}
 	});
 	$effect(() => {

--- a/svelte-maplibre-gl/src/lib/sources/RawSource.svelte
+++ b/svelte-maplibre-gl/src/lib/sources/RawSource.svelte
@@ -52,7 +52,7 @@
 			}
 		}
 	});
-	// ensure it runs before options change (child effects run after parent conponent's effects)
+	// ensure it runs before options change (child effects run after parent component's effects)
 	$effect.pre(() => {
 		if (
 			source &&


### PR DESCRIPTION
When doing at the same time: 
 - a change in tiles URL
 - a change in map options (zoom, center, etc) 
 
 The `$effect`s are batched by components, so `Map.svelte` flushes them before resolving children like `RazSource.svelte`, which means the map is reacting to options change on a stale tiles URL. 
 
 Switching to `$effect.pre` enables tiles reactivity before camera movements. 
 
A small hack is needed to set the tiles synchronously so that the value is correct, because `setTiles` being async, the updated value is resolved at a later animation frame. (A fix upstream in `maplibre` will allow to remove the hack)