### PR TITLE
chore: update MapLibre GL JS baseline to 6.3

### DIFF
--- a/.changeset/rounded-buildings-smile.md
+++ b/.changeset/rounded-buildings-smile.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre-gl': patch
+---
+
+Update the MapLibre GL JS development baseline to 6.3.0 and demonstrate rounded corners for 3D fill extrusions.

--- a/.changeset/rounded-buildings-smile.md
+++ b/.changeset/rounded-buildings-smile.md
@@ -1,5 +1,0 @@
----
-'svelte-maplibre-gl': patch
----
-
-Update the MapLibre GL JS development baseline to 6.3.0 and demonstrate rounded corners for 3D fill extrusions.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ catalogs:
       specifier: ^0.1.0
       version: 0.1.0
     maplibre-gl:
-      specifier: 6.0.0
-      version: 6.0.0
+      specifier: 6.3.0
+      version: 6.3.0
     pmtiles:
       specifier: ^4.4.1
       version: 4.4.1
@@ -168,7 +168,7 @@ importers:
         version: 0.1.0
       maplibre-gl:
         specifier: 'catalog:'
-        version: 6.0.0
+        version: 6.3.0
       mdsvex:
         specifier: ^0.12.7
         version: 0.12.7(svelte@5.55.7(@typescript-eslint/types@8.59.2))
@@ -228,7 +228,7 @@ importers:
         version: 1.30.0
       terra-draw-maplibre-gl-adapter:
         specifier: 1.3.0
-        version: 1.3.0(maplibre-gl@6.0.0)(terra-draw@1.30.0)
+        version: 1.3.0(maplibre-gl@6.3.0)(terra-draw@1.30.0)
       three:
         specifier: ^0.184.0
         version: 0.184.0
@@ -264,7 +264,7 @@ importers:
         version: 0.1.0
       maplibre-gl:
         specifier: 'catalog:'
-        version: 6.0.0
+        version: 6.3.0
       publint:
         specifier: 'catalog:'
         version: 0.3.20
@@ -306,7 +306,7 @@ importers:
         version: 7.1.2(svelte@5.55.7(@typescript-eslint/types@8.59.2))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.2)(jiti@2.7.0))
       maplibre-gl:
         specifier: 'catalog:'
-        version: 6.0.0
+        version: 6.3.0
       publint:
         specifier: 'catalog:'
         version: 0.3.20
@@ -339,7 +339,7 @@ importers:
         version: 7.1.2(svelte@5.55.7(@typescript-eslint/types@8.59.2))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.2)(jiti@2.7.0))
       maplibre-gl:
         specifier: 'catalog:'
-        version: 6.0.0
+        version: 6.3.0
       pmtiles:
         specifier: 'catalog:'
         version: 4.4.1
@@ -375,7 +375,7 @@ importers:
         version: 7.1.2(svelte@5.55.7(@typescript-eslint/types@8.59.2))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.2)(jiti@2.7.0))
       maplibre-gl:
         specifier: 'catalog:'
-        version: 6.0.0
+        version: 6.3.0
       publint:
         specifier: 'catalog:'
         version: 0.3.20
@@ -393,7 +393,7 @@ importers:
         version: 1.30.0
       terra-draw-maplibre-gl-adapter:
         specifier: 1.3.0
-        version: 1.3.0(maplibre-gl@6.0.0)(terra-draw@1.30.0)
+        version: 1.3.0(maplibre-gl@6.3.0)(terra-draw@1.30.0)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -417,7 +417,7 @@ importers:
         version: 7946.0.16
       maplibre-gl:
         specifier: 'catalog:'
-        version: 6.0.0
+        version: 6.3.0
       publint:
         specifier: 'catalog:'
         version: 0.3.20
@@ -1174,8 +1174,8 @@ packages:
   '@maplibre/geojson-vt@6.1.1':
     resolution: {integrity: sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==}
 
-  '@maplibre/maplibre-gl-style-spec@26.1.0':
-    resolution: {integrity: sha512-JaVj0XqDWFb2xfaRFCvF2Gi7qSpCYXXJlVghDDfRUV2dks61YsQKDjlZKT3H+oVwFBxX7CjErz9zjdGTEP/Lug==}
+  '@maplibre/maplibre-gl-style-spec@26.2.1':
+    resolution: {integrity: sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==}
     hasBin: true
 
   '@maplibre/mlt@1.1.12':
@@ -2408,8 +2408,8 @@ packages:
   maplibre-contour@0.1.0:
     resolution: {integrity: sha512-H8muT7JWYE4oLbFv7L2RSbIM1NOu5JxjA9P/TQqhODDnRChE8ENoDkQIWOKgfcKNU77ypLk2ggGoh4/pt4UPLA==}
 
-  maplibre-gl@6.0.0:
-    resolution: {integrity: sha512-1wBgEhzTZfA+cDpFdt0fM1mJA5mJ90fifORJ7D8JcKLJCvPT/iTx9bNxkP7DqEYde65DJd7gE7h83khwNRqdyg==}
+  maplibre-gl@6.3.0:
+    resolution: {integrity: sha512-F0Is48MTzn3DvOEidPjh68E0kuSA7hdzY1YIR0ypPtFgcif3WPtzI1oZFgsv9WtHmarQnbwIXfsf+EfQYvM00A==}
     engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   mdast-util-to-hast@13.2.1:
@@ -4021,7 +4021,7 @@ snapshots:
     dependencies:
       kdbush: 4.1.0
 
-  '@maplibre/maplibre-gl-style-spec@26.1.0':
+  '@maplibre/maplibre-gl-style-spec@26.2.1':
     dependencies:
       '@mapbox/jsonlint-lines-primitives': 2.0.3
       '@mapbox/unitbezier': 1.0.0
@@ -5218,14 +5218,14 @@ snapshots:
 
   maplibre-contour@0.1.0: {}
 
-  maplibre-gl@6.0.0:
+  maplibre-gl@6.3.0:
     dependencies:
       '@mapbox/point-geometry': 1.1.0
       '@mapbox/tiny-sdf': 2.2.0
       '@mapbox/unitbezier': 1.0.0
       '@mapbox/vector-tile': 3.0.0
       '@maplibre/geojson-vt': 6.1.1
-      '@maplibre/maplibre-gl-style-spec': 26.1.0
+      '@maplibre/maplibre-gl-style-spec': 26.2.1
       '@maplibre/mlt': 1.1.12
       '@maplibre/vt-pbf': 4.3.2
       '@types/geojson': 7946.0.16
@@ -5796,9 +5796,9 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terra-draw-maplibre-gl-adapter@1.3.0(maplibre-gl@6.0.0)(terra-draw@1.30.0):
+  terra-draw-maplibre-gl-adapter@1.3.0(maplibre-gl@6.3.0)(terra-draw@1.30.0):
     dependencies:
-      maplibre-gl: 6.0.0
+      maplibre-gl: 6.3.0
       terra-draw: 1.30.0
 
   terra-draw@1.30.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,7 @@ catalog:
   '@sveltejs/vite-plugin-svelte': ^7.1.2
   '@types/geojson': ^7946.0.16
   maplibre-contour: ^0.1.0
-  maplibre-gl: 6.0.0
+  maplibre-gl: 6.3.0
   pmtiles: ^4.4.1
   publint: ^0.3.20
   svelte: ^5.55.7

--- a/src/content/examples/3d-buildings/Buildings3D.svelte
+++ b/src/content/examples/3d-buildings/Buildings3D.svelte
@@ -38,6 +38,9 @@
 		sourceLayer="building"
 		minzoom={14}
 		filter={['!=', ['get', 'hide_3d'], true]}
+		layout={{
+			'fill-extrusion-rounded-corner-distance': 2
+		}}
 		paint={{
 			'fill-extrusion-color': [
 				'interpolate',

--- a/src/content/examples/3d-buildings/content.svelte.md
+++ b/src/content/examples/3d-buildings/content.svelte.md
@@ -11,6 +11,8 @@ original: https://maplibre.org/maplibre-gl-js/docs/examples/display-buildings-in
   let { shiki } = $props();
 </script>
 
+Rounded corners require MapLibre GL JS 6.3 or later.
+
 <Demo />
 
 <CodeBlock content={demoRaw} {shiki} />

--- a/src/content/examples/3d-buildings/content.svelte.md
+++ b/src/content/examples/3d-buildings/content.svelte.md
@@ -1,6 +1,6 @@
 ---
 title: 3D Buildings
-description: Use extrusions to display buildings' height in 3D.
+description: Use extrusions with rounded corners to display buildings' height in 3D.
 original: https://maplibre.org/maplibre-gl-js/docs/examples/display-buildings-in-3d/
 ---
 

--- a/svelte-maplibre-gl/src/lib/contexts.svelte.ts
+++ b/svelte-maplibre-gl/src/lib/contexts.svelte.ts
@@ -24,7 +24,7 @@ class MapContext {
 	/** Map instance */
 	_map: maplibregl.Map | null = $state.raw(null);
 	/** Callbacks to be called when the map style is loaded */
-	private _listener?: maplibregl.Listener = undefined;
+	private _listener?: (ev: maplibregl.MapStyleDataEvent) => void = undefined;
 	private _pending: ((map: maplibregl.Map) => void)[] = [];
 	/** Names of layers dynamically added */
 	userLayers = new SvelteSet<string>();

--- a/svelte-maplibre-gl/src/lib/markers/Popup.svelte
+++ b/svelte-maplibre-gl/src/lib/markers/Popup.svelte
@@ -120,7 +120,7 @@
 	});
 
 	$effect(() => {
-		function _onopen(ev: unknown) {
+		function _onopen(ev: maplibregl.Event) {
 			open = true;
 			internalOpen = true;
 			onopen?.(ev);
@@ -132,7 +132,7 @@
 	});
 
 	$effect(() => {
-		function _onclose(ev: unknown) {
+		function _onclose(ev: maplibregl.Event) {
 			open = false;
 			internalOpen = false;
 			onclose?.(ev);

--- a/svelte-maplibre-gl/src/lib/utils.ts
+++ b/svelte-maplibre-gl/src/lib/utils.ts
@@ -16,18 +16,28 @@ export function generateSourceID() {
  *
  * Intended to be used within the $effect rune.
  */
-export function resetEventListener(
-	evented: maplibregl.Evented | null | undefined,
+export function resetEventListener<TEvent>(
+	evented: unknown,
 	type: string,
-	listener: maplibregl.Listener | undefined
+	listener: ((event: TEvent) => unknown) | undefined
 ) {
+	// Event map and listener payload types became stricter in MapLibre GL JS 6.3.
+	// Cast only the shared on/off surface to preserve MapLibre 5 compatibility
+	// while retaining each caller's specific event payload type.
+	const target = evented as
+		| {
+				on(type: string, listener: (event: TEvent) => unknown): unknown;
+				off(type: string, listener: (event: TEvent) => unknown): unknown;
+		  }
+		| null
+		| undefined;
 	if (listener) {
-		evented?.on(type, listener);
+		target?.on(type, listener);
 	}
 	const prevListener = listener;
 	return () => {
 		if (prevListener) {
-			evented?.off(type, prevListener);
+			target?.off(type, prevListener);
 		}
 	};
 }
@@ -37,11 +47,11 @@ export function resetEventListener(
  *
  * Intended to be used within the $effect rune.
  */
-export function resetLayerEventListener(
+export function resetLayerEventListener<T extends keyof maplibregl.MapLayerEventType>(
 	map: maplibregl.Map | null,
-	type: keyof maplibregl.MapLayerEventType,
+	type: T,
 	layer: string,
-	listener: maplibregl.Listener | undefined
+	listener: ((event: maplibregl.MapLayerEventType[T]) => void) | undefined
 ) {
 	if (listener) {
 		map?.on(type, layer, listener);

--- a/svelte-maplibre-gl/src/lib/utils.ts
+++ b/svelte-maplibre-gl/src/lib/utils.ts
@@ -16,8 +16,13 @@ export function generateSourceID() {
  *
  * Intended to be used within the $effect rune.
  */
+type EventedLike = {
+	on: (...args: never[]) => unknown;
+	off: (...args: never[]) => unknown;
+};
+
 export function resetEventListener<TEvent>(
-	evented: unknown,
+	evented: EventedLike | null | undefined,
 	type: string,
 	listener: ((event: TEvent) => unknown) | undefined
 ) {


### PR DESCRIPTION
### What I did

- Updated the development baseline of MapLibre GL JS from 6.0.0 to 6.3.0.
- Adapted internal event-listener types to the stricter event maps in MapLibre GL JS 6.3.
  - Updated the `styledata` listener to use `MapStyleDataEvent`.
  - Kept the shared listener helper constrained to objects with `on` and `off`.
  - Linked layer event names to their corresponding `MapLayerEventType` payloads.
  - Updated internal Popup event handlers from `unknown` to `maplibregl.Event`.
- Added `fill-extrusion-rounded-corner-distance` to the existing 3D buildings example and documented that rounded corners require MapLibre GL JS 6.3 or later.

The public peer dependency range remains unchanged:

```json
"maplibre-gl": "^5.19.0 || ^6.0.0"
```

### Scope

These changes update repository typechecking and v6-oriented docs/examples without changing the exported consumer API, so this PR does not include a package changeset. The v5 compatibility checks cover the published packages; docs and examples follow the catalog version.