### PR TITLE
fix: preserve fullscreen listeners after control recreation

### DIFF
--- a/.changeset/fresh-buttons-listen.md
+++ b/.changeset/fresh-buttons-listen.md
@@ -1,0 +1,5 @@
+---
+'svelte-maplibre-gl': patch
+---
+
+Preserve fullscreen event listeners when the FullScreenControl is recreated after its options change.

--- a/e2e/fullscreen-control-listener-lifecycle.e2e.ts
+++ b/e2e/fullscreen-control-listener-lifecycle.e2e.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+
+test('fullscreen listeners survive control recreation', async ({ page }) => {
+	const errors: string[] = [];
+	page.on('pageerror', (err) => errors.push(err.message.split('\n')[0]));
+
+	await page.goto('/test/fullscreen-control-listener-lifecycle/');
+	await page.getByTestId('recreate-fullscreen-control').click();
+
+	const fullscreenButton = page.locator('.maplibregl-ctrl-fullscreen');
+	await expect(fullscreenButton).toBeVisible();
+	await fullscreenButton.click();
+	await expect(page.getByTestId('fullscreen-events')).toHaveText('1:0');
+
+	await page.locator('.maplibregl-ctrl-shrink').click();
+	await expect(page.getByTestId('fullscreen-events')).toHaveText('1:1');
+
+	expect(errors).toEqual([]);
+});

--- a/e2e/fullscreen-control-listener-lifecycle.e2e.ts
+++ b/e2e/fullscreen-control-listener-lifecycle.e2e.ts
@@ -5,7 +5,15 @@ test('fullscreen listeners survive control recreation', async ({ page }) => {
 	page.on('pageerror', (err) => errors.push(err.message.split('\n')[0]));
 
 	await page.goto('/test/fullscreen-control-listener-lifecycle/');
+
+	const initialFullscreenButton = page.locator('.maplibregl-ctrl-fullscreen');
+	await expect(initialFullscreenButton).toBeVisible();
+	const initialHandle = await initialFullscreenButton.elementHandle();
+
 	await page.getByTestId('recreate-fullscreen-control').click();
+	if (initialHandle) {
+		await page.waitForFunction((el) => !el.isConnected, initialHandle);
+	}
 
 	const fullscreenButton = page.locator('.maplibregl-ctrl-fullscreen');
 	await expect(fullscreenButton).toBeVisible();

--- a/src/routes/test/fullscreen-control-listener-lifecycle/+page.svelte
+++ b/src/routes/test/fullscreen-control-listener-lifecycle/+page.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import 'svelte-maplibre-gl/vite';
+	import type { StyleSpecification } from 'maplibre-gl';
+	import { FullScreenControl, MapLibre } from 'svelte-maplibre-gl';
+
+	let pseudo = $state(false);
+	let starts = $state(0);
+	let ends = $state(0);
+
+	const style = {
+		version: 8,
+		sources: {},
+		layers: [{ id: 'background', type: 'background', paint: { 'background-color': '#ffffff' } }]
+	} satisfies StyleSpecification;
+</script>
+
+<button type="button" data-testid="recreate-fullscreen-control" onclick={() => (pseudo = true)}>
+	Recreate fullscreen control
+</button>
+
+<MapLibre {style} class="h-[200px] w-full" zoom={1} center={{ lng: 0, lat: 0 }}>
+	<FullScreenControl {pseudo} onfullscreenstart={() => starts++} onfullscreenend={() => ends++} />
+</MapLibre>
+
+<output data-testid="fullscreen-events">{starts}:{ends}</output>

--- a/svelte-maplibre-gl/src/lib/controls/FullScreenControl.svelte
+++ b/svelte-maplibre-gl/src/lib/controls/FullScreenControl.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	// https://maplibre.org/maplibre-gl-js/docs/API/classes/FullscreenControl/
 
-	import { onDestroy } from 'svelte';
 	import * as maplibregl from 'maplibre-gl';
 	import { getMapContext } from '../contexts.svelte.js';
 	import { resetEventListener } from '../utils.js';
@@ -21,19 +20,18 @@
 	const mapCtx = getMapContext();
 	if (!mapCtx.map) throw new Error('Map instance is not initialized.');
 
-	let control: maplibregl.FullscreenControl | null = null;
+	let control = $state.raw<maplibregl.FullscreenControl | null>(null);
 	$effect(() => {
-		control && mapCtx.map?.removeControl(control);
-		control = new maplibregl.FullscreenControl(options);
-		mapCtx.map?.addControl(control, position);
+		const map = mapCtx.map;
+		const currentControl = new maplibregl.FullscreenControl(options);
+		map?.addControl(currentControl, position);
+		control = currentControl;
+
+		return () => {
+			map?.removeControl(currentControl);
+		};
 	});
 
 	$effect(() => resetEventListener(control, 'fullscreenstart', onfullscreenstart));
 	$effect(() => resetEventListener(control, 'fullscreenend', onfullscreenend));
-
-	onDestroy(() => {
-		if (control) {
-			mapCtx.map?.removeControl(control);
-		}
-	});
 </script>


### PR DESCRIPTION
  ## Summary

  Fix `FullScreenControl` event listeners becoming detached when the underlying MapLibre control is recreated.

  ## Problem

  `FullScreenControl` recreates its MapLibre control when options such as `pseudo` or `position` change.

  Previously, the `control` variable was not reactive. As a result, the listener effects did not run again after the control changed:

  1. Event listeners were registered on Control A.
  2. Changing an option removed Control A and created Control B.
  3. Control B was displayed without `fullscreenstart` or `fullscreenend` listeners.
  4. Fullscreen itself continued to work, but the Svelte callbacks were no longer called.

  ## Before

  After enabling `pseudo` to recreate the control, entering and leaving fullscreen does not update the event counters. UI that depends on the callbacks also remains in the wrong state.


https://github.com/user-attachments/assets/5ac5daa6-cfdb-4cc8-8150-76eba78e0709



  ## After

  The listener effects now react to control replacement and register the callbacks on the new control. The event counters and callback-dependent UI update correctly after recreation.


https://github.com/user-attachments/assets/930f14cc-1112-40a3-bf98-39f361919432



  ## Changes

  - Track the `FullscreenControl` reference with `$state.raw`.
  - Let each creation effect clean up the exact control instance it created.
  - Re-register fullscreen event listeners when the control reference changes.
  - Remove the redundant `onDestroy` cleanup.
  - Add a Playwright regression fixture and test.
  - Add a patch changeset.

  ## Testing

  - `pnpm run ci:check-unit`
  - `pnpm run check:maplibre-5`
  - `pnpm --filter svelte-maplibre-gl check`
  - Targeted Playwright regression test

  The regression test verifies that `fullscreenstart` and `fullscreenend` are still received after changing `pseudo` and recreating the control.