### PR TITLE
docs(example): replace "Dynamic Image" with "GPU-Animated Image"

### DIFF
--- a/e2e/examples-smoke.e2e.ts
+++ b/e2e/examples-smoke.e2e.ts
@@ -10,6 +10,11 @@ const slugs = fs
 	.filter((entry) => entry.isDirectory())
 	.map((entry) => entry.name)
 	.sort();
+const [maplibreMajor, maplibreMinor] = (process.env.MAPLIBRE_GL_VERSION ?? '')
+	.split('.')
+	.map((part) => Number.parseInt(part, 10));
+const lacksWebGLStyleImages =
+	Number.isFinite(maplibreMajor) && (maplibreMajor < 6 || (maplibreMajor === 6 && maplibreMinor < 3));
 
 // Smoke check: visit each example and assert the page does not raise any
 // uncaught errors. This catches addLayer/addSource crashes, missing imports,
@@ -21,6 +26,11 @@ test.describe('examples smoke', () => {
 
 	for (const slug of slugs) {
 		test(slug, async ({ page }) => {
+			test.skip(
+				lacksWebGLStyleImages && slug === 'dynamic-image',
+				'GPU-rendered style images require MapLibre GL JS 6.3 or later'
+			);
+
 			const errors: string[] = [];
 			page.on('pageerror', (err) => errors.push(err.message.split('\n')[0]));
 

--- a/scripts/with-maplibre-version.mjs
+++ b/scripts/with-maplibre-version.mjs
@@ -146,7 +146,9 @@ try {
 	if (installStatus !== 0) {
 		process.exitCode = installStatus;
 	} else if (command.length > 0) {
-		process.exitCode = run(command[0], command.slice(1));
+		process.exitCode = run(command[0], command.slice(1), {
+			env: { ...process.env, MAPLIBRE_GL_VERSION: resolvedVersion }
+		});
 	} else {
 		console.log(`Installed maplibre-gl@${resolvedVersion}. No command was provided.`);
 	}

--- a/src/content/examples/dynamic-image/DynamicImage.svelte
+++ b/src/content/examples/dynamic-image/DynamicImage.svelte
@@ -1,44 +1,114 @@
 <script lang="ts">
 	import 'svelte-maplibre-gl/vite'; // Required only for GL JS v6+
+	import type * as maplibregl from 'maplibre-gl';
 	import { MapLibre, Image, GeoJSONSource, SymbolLayer } from 'svelte-maplibre-gl';
 
-	const size = 64;
-	const data = new Uint8Array(size * size * 4);
+	const SIZE = 128;
+	const CITIES = [
+		[141.35, 43.06],
+		[139.69, 35.68],
+		[136.91, 35.18],
+		[135.5, 34.69],
+		[132.46, 34.4],
+		[130.4, 33.59]
+	];
 
-	let p = 0;
-	for (let x = 0; x < size; x++) {
-		for (let y = 0; y < size; y++) {
-			data[p + 0] = (y / size) * 255;
-			data[p + 1] = (x / size) * 255;
-			data[p + 2] = 128;
-			data[p + 3] = 255;
-			p += 4;
-		}
+	const VERTEX_SHADER = `#version 300 es
+	const vec2 p[3] = vec2[3](vec2(-1, -1), vec2(3, -1), vec2(-1, 3));
+	out vec2 uv;
+	void main() { gl_Position = vec4(p[gl_VertexID], 0, 1); uv = p[gl_VertexID] * .5 + .5; }`;
+
+	const FRAGMENT_SHADER = `#version 300 es
+	precision highp float;
+	in vec2 uv; uniform float time; out vec4 color;
+	void main() {
+		vec2 p = uv * 2. - 1.; float r = length(p), a = atan(p.y, p.x);
+		float ring = .02 / abs(r - .48 - .07 * sin(a * 6. - time * 2.));
+		float spark = .015 / abs(length(p - .55 * vec2(cos(time), sin(time))) - .06);
+		float alpha = smoothstep(1., .72, r) * clamp(.08 + ring + spark, 0., 1.);
+		vec3 neon = .5 + .5 * cos(time + r * 7. + vec3(0., 2., 4.));
+		color = vec4(neon * alpha, alpha);
+	}`;
+
+	let map: maplibregl.Map | undefined;
+	let gl: WebGL2RenderingContext | undefined;
+	let program: WebGLProgram | null;
+	let framebuffer: WebGLFramebuffer | null;
+	let timeLocation: WebGLUniformLocation | null;
+
+	function compileShader(context: WebGL2RenderingContext, type: number, source: string) {
+		const shader = context.createShader(type)!;
+		context.shaderSource(shader, source);
+		context.compileShader(shader);
+		return shader;
 	}
+
+	function setup(context: WebGL2RenderingContext) {
+		gl = context;
+		program = context.createProgram();
+		context.attachShader(program!, compileShader(context, context.VERTEX_SHADER, VERTEX_SHADER));
+		context.attachShader(program!, compileShader(context, context.FRAGMENT_SHADER, FRAGMENT_SHADER));
+		context.linkProgram(program!);
+		timeLocation = context.getUniformLocation(program!, 'time');
+		framebuffer = context.createFramebuffer();
+	}
+
+	function destroy() {
+		if (!gl) return;
+		gl.deleteProgram(program);
+		gl.deleteFramebuffer(framebuffer);
+		gl = undefined;
+		program = framebuffer = timeLocation = null;
+	}
+
+	const gpuImage: maplibregl.StyleImageInterface = {
+		width: SIZE,
+		height: SIZE,
+		onAdd(value) {
+			map = value;
+		},
+		render() {
+			map?.triggerRepaint();
+			return true;
+		},
+		data: {
+			renderWithWebGL(target) {
+				if (gl !== target.gl) setup(target.gl);
+				target.gl.bindFramebuffer(target.gl.FRAMEBUFFER, framebuffer);
+				target.gl.framebufferTexture2D(
+					target.gl.FRAMEBUFFER,
+					target.gl.COLOR_ATTACHMENT0,
+					target.gl.TEXTURE_2D,
+					target.texture,
+					0
+				);
+				target.gl.viewport(target.x, target.y, target.width, target.height);
+				target.gl.useProgram(program);
+				target.gl.uniform1f(timeLocation, performance.now() / 1000);
+				target.gl.drawArrays(target.gl.TRIANGLES, 0, 3);
+			}
+		},
+		onRemove: destroy
+	};
 </script>
 
 <MapLibre
 	class="h-[55vh] min-h-75"
-	style="https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json"
+	style="https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json"
 	zoom={4}
-	center={{ lng: 137, lat: 36 }}
+	center={{ lng: 136.5, lat: 37.5 }}
 >
-	<Image id="gradient" image={{ width: size, height: size, data }} />
+	<Image id="gpu-signal" image={gpuImage} options={{ pixelRatio: 2 }} />
 	<GeoJSONSource
 		data={{
 			type: 'FeatureCollection',
-			features: [
-				{
-					type: 'Feature',
-					geometry: {
-						type: 'Point',
-						coordinates: [137, 36]
-					},
-					properties: {}
-				}
-			]
+			features: CITIES.map((coordinates) => ({
+				type: 'Feature' as const,
+				geometry: { type: 'Point' as const, coordinates },
+				properties: {}
+			}))
 		}}
 	>
-		<SymbolLayer layout={{ 'icon-image': 'gradient' }} />
+		<SymbolLayer layout={{ 'icon-image': 'gpu-signal', 'icon-allow-overlap': true }} />
 	</GeoJSONSource>
 </MapLibre>

--- a/src/content/examples/dynamic-image/content.svelte.md
+++ b/src/content/examples/dynamic-image/content.svelte.md
@@ -1,7 +1,7 @@
 ---
-title: Dynamic Image
-description: Add an icon to the map that was generated at runtime.
-original: https://maplibre.org/maplibre-gl-js/docs/examples/add-a-generated-icon-to-the-map/
+title: GPU-Animated Image
+description: Render an animated icon directly into the style image atlas with a WebGL shader.
+original: https://maplibre.org/maplibre-gl-js/docs/examples/animate-an-icon-on-the-gpu/
 ---
 
 <script lang="ts">

--- a/src/content/examples/toc.ts
+++ b/src/content/examples/toc.ts
@@ -49,7 +49,7 @@ export const toc: Toc = [
 			'/examples/custom-protocol': 'Custom Protocols',
 			'/examples/canvas-source': 'Canvas Source',
 			'/examples/custom-layer': 'Custom Layer',
-			'/examples/dynamic-image': 'Dynamic Image',
+			'/examples/dynamic-image': 'GPU-Animated Image',
 			'/examples/threejs-model': '3D model with three.js'
 		}
 	},


### PR DESCRIPTION
Replaces the static generated-image example with a GPU-animated style image rendered by a compact WebGL shader.

https://maplibre.org/maplibre-gl-js/docs/examples/animate-an-icon-on-the-gpu/