### PR TITLE
fix: remove replaced custom controls

### DIFF
--- a/.changeset/calm-controls-clean.md
+++ b/.changeset/calm-controls-clean.md
@@ -1,0 +1,5 @@
+---
+"svelte-maplibre-gl": patch
+---
+
+Remove the previous custom control from the map when the `control` prop changes.

--- a/.changeset/calm-controls-clean.md
+++ b/.changeset/calm-controls-clean.md
@@ -1,5 +1,5 @@
 ---
-"svelte-maplibre-gl": patch
+'svelte-maplibre-gl': patch
 ---
 
 Remove the previous custom control from the map when the `control` prop changes.

--- a/e2e/custom-control-swap.e2e.ts
+++ b/e2e/custom-control-swap.e2e.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+
+test('swapping a custom control removes the previous one', async ({ page }) => {
+	const errors: string[] = [];
+	page.on('pageerror', (err) => errors.push(err.message.split('\n')[0]));
+
+	await page.goto('/test/custom-control-swap/');
+
+	await expect(page.getByTestId('custom-control-a')).toBeVisible();
+	await expect(page.getByTestId('custom-control-b')).toHaveCount(0);
+
+	await page.getByTestId('swap-custom-control').click();
+
+	await expect(page.getByTestId('custom-control-b')).toBeVisible();
+	// The previously added control must be removed, not left behind on the map.
+	await expect(page.getByTestId('custom-control-a')).toHaveCount(0);
+
+	expect(errors).toEqual([]);
+});

--- a/src/routes/test/custom-control-swap/+page.svelte
+++ b/src/routes/test/custom-control-swap/+page.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import 'svelte-maplibre-gl/vite';
+	import type { IControl, StyleSpecification } from 'maplibre-gl';
+	import { CustomControl, MapLibre } from 'svelte-maplibre-gl';
+
+	function makeControl(label: string): IControl {
+		let el: HTMLDivElement | undefined;
+		return {
+			onAdd: () => {
+				el = document.createElement('div');
+				el.className = 'maplibregl-ctrl maplibregl-ctrl-group';
+				el.dataset.testid = `custom-control-${label}`;
+				el.textContent = label;
+				return el;
+			},
+			onRemove: () => {
+				el?.parentNode?.removeChild(el);
+				el = undefined;
+			}
+		};
+	}
+
+	const first = makeControl('a');
+	const second = makeControl('b');
+	let control = $state<IControl>(first);
+
+	const style = {
+		version: 8,
+		sources: {},
+		layers: [{ id: 'background', type: 'background', paint: { 'background-color': '#ffffff' } }]
+	} satisfies StyleSpecification;
+</script>
+
+<button type="button" data-testid="swap-custom-control" onclick={() => (control = second)}>
+	Swap custom control
+</button>
+
+<MapLibre {style} class="h-[200px] w-full" zoom={1} center={{ lng: 0, lat: 0 }}>
+	<CustomControl {control} />
+</MapLibre>

--- a/svelte-maplibre-gl/src/lib/controls/CustomControl.svelte
+++ b/svelte-maplibre-gl/src/lib/controls/CustomControl.svelte
@@ -39,11 +39,16 @@
 	});
 
 	$effect(() => {
-		if (control) {
-			mapCtx.map?.addControl(control, position);
+		const map = mapCtx.map;
+		const currentControl = control;
+		if (currentControl) {
+			map?.addControl(currentControl, position);
 		}
+
 		return () => {
-			control && mapCtx.map?.removeControl(control);
+			if (currentControl) {
+				map?.removeControl(currentControl);
+			}
 		};
 	});
 </script>


### PR DESCRIPTION
Applies the lifecycle cleanup pattern from #199 to CustomControl so replacing the control removes the previously mounted instance.